### PR TITLE
added support for tokens not from a smart card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+DeveloperSettings.xcconfig

--- a/SC-Menu-Shared.xcconfig
+++ b/SC-Menu-Shared.xcconfig
@@ -1,0 +1,3 @@
+DEVELOPMENT_TEAM = 2WUMX954UB
+
+#include? "DeveloperSettings.xcconfig"

--- a/smartcard_menu.xcodeproj/project.pbxproj
+++ b/smartcard_menu.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		734F914C2B95719F005C24ED /* smartcard_in_bw.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = smartcard_in_bw.png; sourceTree = "<group>"; };
 		734F914D2B95719F005C24ED /* smartcard_out_bw.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = smartcard_out_bw.png; sourceTree = "<group>"; };
 		735C9DFD2B941082005EBF0B /* PreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
+		766E3E742CC9F68500BB0920 /* SC-Menu-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "SC-Menu-Shared.xcconfig"; sourceTree = "<group>"; };
 		860203512B84F2DE00E84186 /* ViewCerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCerts.swift; sourceTree = "<group>"; };
 		862CDBB52B911BD000E75D2D /* ATR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATR.swift; sourceTree = "<group>"; };
 		862CDBB72B91209A00E75D2D /* WebWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebWindow.swift; sourceTree = "<group>"; };
@@ -62,6 +63,7 @@
 			children = (
 				86FF1DC22B7FA45A007F3959 /* smartcard_menu */,
 				86FF1DC12B7FA45A007F3959 /* Products */,
+				766E3E742CC9F68500BB0920 /* SC-Menu-Shared.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -320,6 +322,7 @@
 		};
 		86FF1DD02B7FA45B007F3959 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 766E3E742CC9F68500BB0920 /* SC-Menu-Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -330,7 +333,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 345;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 2WUMX954UB;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "SC Menu";
@@ -355,6 +357,7 @@
 		};
 		86FF1DD12B7FA45B007F3959 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 766E3E742CC9F68500BB0920 /* SC-Menu-Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -365,7 +368,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 345;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 2WUMX954UB;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "SC Menu";

--- a/smartcard_menu/PreferencesViewController.swift
+++ b/smartcard_menu/PreferencesViewController.swift
@@ -10,7 +10,7 @@ import Cocoa
 import os
 
 protocol PrefDataModelDelegate {
-    func didRecievePrefUpdate()
+    func didReceivePrefUpdate()
 }
 
 class PreferencesViewController: NSViewController {
@@ -144,14 +144,14 @@ class PreferencesViewController: NSViewController {
         if sender.title == "Black and White" {
             UserDefaults.standard.set("bw", forKey: "icon_mode")
             os_log("B&W Icon selected", log: prefsLog, type: .default)
-            self.delegate?.didRecievePrefUpdate()
+            self.delegate?.didReceivePrefUpdate()
             
         }
         
         if sender.title == "Colorful" {
             UserDefaults.standard.set("colorful", forKey: "icon_mode")
             os_log("Colorful Icon selected", log: prefsLog, type: .default)
-            self.delegate?.didRecievePrefUpdate()
+            self.delegate?.didReceivePrefUpdate()
         }
     }
     


### PR DESCRIPTION
I tried using sc_menu with our bluetooth reader and it didn't show any certificates. To resolve this, I added a func to look for inserted token types when the menu is opened and to populate them. It gets all the tokens using:

myTKWatcher?.tokenIDs and then iterates over them and inserts any configs. I had to make a change in showReader since it checked for a locked card which only works if a physical reader is available. i just added a filter to see if the token had a name with "apple" in it and if so, didn't insert the error message.

I also inserted a CTK built in token using :
sc_auth import-ctk-identities -f PIV.p12

Here is what it looks like:
<img width="932" alt="one" src="https://github.com/user-attachments/assets/fba521aa-49e6-464d-b9fd-e98e8f64e617">
<img width="617" alt="two" src="https://github.com/user-attachments/assets/23419a9a-5fa9-4694-b044-2fa8a08bbe84">
